### PR TITLE
Логгировать только CRITICAL для tg bot updater

### DIFF
--- a/src/samowarium.py
+++ b/src/samowarium.py
@@ -44,6 +44,8 @@ def setup_logger():
         level=LOGGER_LEVEL,
     )
     logging.getLogger("httpx").setLevel(logging.WARN)
+    if env.is_prod_profile():
+        logging.getLogger("telegram.ext.Updater").setLevel(logging.CRITICAL)
 
 
 async def main() -> None:


### PR DESCRIPTION
Надоело, что в логах регуряно появляется куча мусорных сообщений, что бот вновь потерял контакт с bot api телеги. Чтобы больше таких логов не было, ставлю лог level для обновлялки CRITICAL